### PR TITLE
createUploadBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -325,7 +325,7 @@ interface GPUDevice : EventTarget {
     readonly attribute object limits;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
-    GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
+    GPUMappedUploadBuffer createUploadBuffer(GPUBufferSize size);
     Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});


### PR DESCRIPTION
**SPECULATIVE PROPOSAL** (on personal fork)

Add createUploadBuffer, which has the explicit purpose of creating
temporary storage for uploads. It is essentially identical to
createBufferMapped, but less flexible: there is no usage field. The
usage can only be MAP_WRITE | COPY_SRC.

The expectation with GPUUploadBuffer is that it would generally be
allocated as CPU memory (e.g. IPC shared memory) - or, if available, a
suballocation in some pre-allocated CPU-coherent memory (e.g.
HOST_COHERENT mapped with dmabuf).