### PR TITLE
Vertex input: description, mental model, naming

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1330,28 +1330,41 @@ enum GPUInputStepMode {
 </script>
 
 <script type=idl>
-dictionary GPUVertexAttributeDescriptor {
-    GPUBufferSize offset = 0;
-    required GPUVertexFormat format;
-    required unsigned long shaderLocation;
-};
-</script>
-
-<script type=idl>
-dictionary GPUVertexBufferDescriptor {
-    required GPUBufferSize stride;
-    GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeDescriptor> attributeSet;
-};
-</script>
-
-<script type=idl>
 dictionary GPUVertexInputDescriptor {
     GPUIndexFormat indexFormat = "uint32";
     sequence<GPUVertexBufferDescriptor?> vertexBuffers = [];
 };
 </script>
 
+A <dfn dfn>vertex buffer</dfn> is a view into buffer memory as an *array of structures*.
+{{GPUVertexBufferDescriptor/elementStride}} is the stride, in bytes, between *elements* of the array.
+Each element of a vertex buffer is a *structure* whose memory layout is defined by
+{{GPUVertexBufferDescriptor/structure}}, which describes the *members* of the structure.
+
+Each {{GPUVertexStructureMemberDescriptor}} describes its
+{{GPUVertexStructureMemberDescriptor/format}} and its
+{{GPUVertexStructureMemberDescriptor/offset}}, in bytes, within the structure.
+
+When used in a vertex shader, members are accessed by their *location*,
+which is specified by {{GPUVertexStructureMemberDescriptor/shaderLocation}}.
+All of the locations must be unique within the {{GPUVertexInputDescriptor}}.
+
+<script type=idl>
+dictionary GPUVertexBufferDescriptor {
+    required GPUBufferSize elementStride;
+    GPUInputStepMode stepMode = "vertex";
+    required sequence<GPUVertexStructureMemberDescriptor> structure;
+};
+</script>
+
+<script type=idl>
+dictionary GPUVertexStructureMemberDescriptor {
+    required GPUVertexFormat format;
+    required GPUBufferSize offset;
+
+    required unsigned long shaderLocation;
+};
+</script>
 
 Command Buffers {#command-buffers}
 ==================================


### PR DESCRIPTION
**SPECULATIVE PROPOSAL** (on personal fork)

I've been struggling with coming up with a mental model for vertex input
ever since we rephrased it in terms of the "push" model. Because we were
talking about vertex pulling recently, in which things can really be
phrased as arrays-of-structures, I realized that was the basis I needed
to make the mental model finally make sense.

The key naming change is that "vertex buffers" no longer contain
"attributes". Instead, they are arrays which contain "structures", and
each structure is defined by a sequence of "members". Those members
*secondarily* specify their shader input location.

I also wrote some text to describe this mental model.

There is also one functional change aside from naming: the attribute
byte offset is no longer optional. I think it's crucial to the mental
modeling that the offset be front-and-center in the vertex structure
definition.